### PR TITLE
Rename to SparsePoleRepresentation

### DIFF
--- a/src/sparse_ir/spr.py
+++ b/src/sparse_ir/spr.py
@@ -5,9 +5,9 @@ from .basis import FiniteTempBasis
 from .sampling import DecomposedMatrix
 
 
-class DLRLike:
+class SparsePoleRepresentation:
     """
-    Representation like Discrete Lehmann representation (DLR)
+    Sparse pole representation (SPR)
     Use a set of poles selected according to the roots of Vl(ω)
     """
     def __init__(self, basis: FiniteTempBasis) -> None:
@@ -36,7 +36,7 @@ class DLRLike:
 
     def from_IR(self, gl: np.ndarray, axis=0) -> np.ndarray:
         """
-        From IR to DLRLike
+        From IR to SPR
 
         gl:
             Expansion coefficients in IR
@@ -46,7 +46,7 @@ class DLRLike:
 
     def evaluate_matsubara(
             self,
-            g_dlr: np.ndarray,
+            g_spr: np.ndarray,
             vsample: np.ndarray,
             axis=0) -> np.ndarray:
         """
@@ -55,10 +55,10 @@ class DLRLike:
         vsample:
             Imaginary frequencies
 
-        g_dlr:
-            DLRLike coefficients
+        g_spr:
+            SPR coefficients
         """
-        coeffs = np.moveaxis(g_dlr, source=axis, destination=0)
+        coeffs = np.moveaxis(g_spr, source=axis, destination=0)
         iv = 1j*vsample * np.pi/self._basis.beta
         giv = np.einsum(
             'wp, p...->w...', 1/(iv[:, None] - self._poles[None, :]), coeffs)

--- a/test/test_spr.py
+++ b/test/test_spr.py
@@ -1,5 +1,5 @@
 import sparse_ir
-from sparse_ir.dlr_like import DLRLike
+from sparse_ir.spr import SparsePoleRepresentation
 from sparse_ir.sampling import MatsubaraSampling
 import numpy as np
 import pytest
@@ -23,7 +23,7 @@ def test_compression(stat):
     eps = 1e-12
     basis = sparse_ir.FiniteTempBasis(
         stat, beta, wmax, eps=eps, kernel=sparse_ir.KernelFFlat(beta*wmax))
-    dlr = DLRLike(basis)
+    spr = SparsePoleRepresentation(basis)
 
     np.random.seed(4711)
 
@@ -34,10 +34,10 @@ def test_compression(stat):
 
     Gl = _to_IR(basis, poles, coeffs)
 
-    g_dlr = dlr.from_IR(Gl)
+    g_spr = spr.from_IR(Gl)
 
     smpl = MatsubaraSampling(basis)
-    giv = dlr.evaluate_matsubara(g_dlr, smpl.sampling_points)
+    giv = spr.evaluate_matsubara(g_spr, smpl.sampling_points)
 
     giv_ref = smpl.evaluate(Gl, axis=0)
 


### PR DESCRIPTION
To avoid any confusion with DLR, let us use a different name because the poles are different.