### PR TITLE
Add a class for holding IR bases and sampling objects

### DIFF
--- a/src/sparse_ir/__init__.py
+++ b/src/sparse_ir/__init__.py
@@ -20,4 +20,5 @@ except ImportError:
 from .kernel import RegularizedBoseKernel, LogisticKernel
 from .sve import compute as compute_sve
 from .basis import IRBasis, FiniteTempBasis, finite_temp_bases
+from .basis_set import FiniteTempBasisSet
 from .sampling import TauSampling, MatsubaraSampling

--- a/src/sparse_ir/basis_set.py
+++ b/src/sparse_ir/basis_set.py
@@ -7,6 +7,34 @@ class FiniteTempBasisSet:
 
     An object of this class holds IR bases for fermion and bosons
     and associated sparse-sampling objects
+
+    Attributes:
+        basis_f (FiniteTempBasis):
+            Fermion basis
+        basis_b (FiniteTempBasis):
+            Boson basis
+        beta (float):
+            Inverse temperature
+        wmax (float):
+            Cut-off frequency
+        eps (float):
+            Cut-off value for singular values
+        tau (1D ndarray of float):
+            Sampling points in the imaginary-time domain
+        wn_f (1D ndarray of int):
+            Sampling fermionic frequencies
+        wn_b (1D ndarray of int):
+            Sampling bosonic frequencies
+        smpl_tau_f (TauSampling):
+            Sparse sampling for tau & fermion
+        smpl_tau_b (TauSampling):
+            Sparse sampling for tau & boson
+        smpl_wn_f (MatsubaraSampling):
+            Sparse sampling for Matsubara frequency & fermion
+        smpl_wn_b (MatsubaraSampling):
+            Sparse sampling for Matsubara frequency & boson
+        sve_result (tuple of three ndarray objects):
+            Results of SVE
     """
     def __init__(self, beta, wmax, eps, sve_result=None):
         """
@@ -34,10 +62,10 @@ class FiniteTempBasisSet:
 
     @property
     def beta(self): return self.basis_f.beta
-    
+
     @property
     def wmax(self): return self.basis_f.wmax
-    
+
     @property
     def sve_result(self): return self.basis_f.sve_result
 

--- a/src/sparse_ir/basis_set.py
+++ b/src/sparse_ir/basis_set.py
@@ -22,19 +22,30 @@ class FiniteTempBasisSet:
             self.basis_f = FiniteTempBasis("F", beta, wmax, eps, sve_result=sve_result)
             self.basis_b = FiniteTempBasis("B", beta, wmax, eps, sve_result=sve_result)
 
-        self.beta = beta
-        self.wmax = wmax
         self.eps = eps
 
         # Tau sampling
         self.smpl_tau_f = TauSampling(self.basis_f)
         self.smpl_tau_b = TauSampling(self.basis_b)
-        self.tau = self.smpl_tau_f.sampling_points
 
         # Matsubara sampling
         self.smpl_wn_f = MatsubaraSampling(self.basis_f)
         self.smpl_wn_b = MatsubaraSampling(self.basis_b)
-        self.wn_f = self.smpl_wn_f.sampling_points
-        self.wn_b = self.smpl_wn_b.sampling_points
 
-        self.sve_result = self.basis_f.sve_result
+    @property
+    def beta(self): return self.basis_f.beta
+    
+    @property
+    def wmax(self): return self.basis_f.wmax
+    
+    @property
+    def sve_result(self): return self.basis_f.sve_result
+
+    @property
+    def tau(self): return self.smpl_tau_f.sampling_points
+
+    @property
+    def wn_f(self): return self.smpl_wn_f.sampling_points
+
+    @property
+    def wn_b(self): return self.smpl_wn_b.sampling_points

--- a/src/sparse_ir/basis_set.py
+++ b/src/sparse_ir/basis_set.py
@@ -1,0 +1,38 @@
+from .basis import FiniteTempBasis, finite_temp_bases
+from .sampling import TauSampling, MatsubaraSampling
+
+
+class FiniteTempBasisSet:
+    """Class for holding IR bases and sparse-sampling objects
+
+    An object of this class holds IR bases for fermion and bosons
+    and associated sparse-sampling objects
+    """
+    def __init__(self, beta, wmax, eps, sve_result=None):
+        """
+        Create basis sets for fermion and boson and
+        associated sampling objects.
+        Fermion and bosonic bases are constructed by SVE of the logistic kernel.
+        """
+        if sve_result is None:
+            # Create bases by sve of the logistic kernel
+            self.basis_f, self.basis_b = finite_temp_bases(beta, wmax, eps)
+        else:
+            # Create bases using the given sve results
+            self.basis_f = FiniteTempBasis("F", beta, wmax, eps, sve_result=sve_result)
+            self.basis_b = FiniteTempBasis("B", beta, wmax, eps, sve_result=sve_result)
+
+        self.beta = beta
+        self.wmax = wmax
+        self.eps = eps
+
+        # Tau sampling
+        self.smpl_tau_f = TauSampling(self.basis_f)
+        self.smpl_tau_b = TauSampling(self.basis_b)
+        self.tau = self.smpl_tau_f.sampling_points
+
+        # Matsubara sampling
+        self.smpl_wn_f = MatsubaraSampling(self.basis_f)
+        self.smpl_wn_b = MatsubaraSampling(self.basis_b)
+        self.wn_f = self.smpl_wn_f.sampling_points
+        self.wn_b = self.smpl_wn_b.sampling_points

--- a/src/sparse_ir/basis_set.py
+++ b/src/sparse_ir/basis_set.py
@@ -36,3 +36,5 @@ class FiniteTempBasisSet:
         self.smpl_wn_b = MatsubaraSampling(self.basis_b)
         self.wn_f = self.smpl_wn_f.sampling_points
         self.wn_b = self.smpl_wn_b.sampling_points
+
+        self.sve_result = self.basis_f.sve_result

--- a/test/test_basis_set.py
+++ b/test/test_basis_set.py
@@ -18,7 +18,8 @@ def test_consistency(use_sve_result):
     smpl_wn_f = MatsubaraSampling(basis_f)
     smpl_wn_b = MatsubaraSampling(basis_b)
 
-    bs = FiniteTempBasisSet(beta, wmax, eps, sve_result=basis_f.sve_result if use_sve_result else None)
+    sve_result=basis_f.sve_result if use_sve_result else None
+    bs = FiniteTempBasisSet(beta, wmax, eps, sve_result=sve_result)
 
     np.testing.assert_array_equal(smpl_tau_f.sampling_points, smpl_tau_b.sampling_points)
     np.testing.assert_array_equal(bs.smpl_tau_f.matrix.a, smpl_tau_f.matrix.a)

--- a/test/test_basis_set.py
+++ b/test/test_basis_set.py
@@ -4,18 +4,21 @@ import numpy as np
 
 from sparse_ir import FiniteTempBasisSet,\
     TauSampling, MatsubaraSampling, finite_temp_bases
+import pytest
 
-def test_consistency():
+@pytest.mark.parametrize("use_sve_result", [True, False])
+def test_consistency(use_sve_result):
     beta = 1.0
     wmax = 10.0
     eps = 1e-5
-    bs = FiniteTempBasisSet(beta, wmax, eps)
 
     basis_f, basis_b = finite_temp_bases(beta, wmax, eps)
     smpl_tau_f = TauSampling(basis_f)
     smpl_tau_b = TauSampling(basis_b)
     smpl_wn_f = MatsubaraSampling(basis_f)
     smpl_wn_b = MatsubaraSampling(basis_b)
+
+    bs = FiniteTempBasisSet(beta, wmax, eps, sve_result=basis_f.sve_result if use_sve_result else None)
 
     np.testing.assert_array_equal(smpl_tau_f.sampling_points, smpl_tau_b.sampling_points)
     np.testing.assert_array_equal(bs.smpl_tau_f.matrix.a, smpl_tau_f.matrix.a)

--- a/test/test_basis_set.py
+++ b/test/test_basis_set.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2020-2021 Markus Wallerberger and others
+# SPDX-License-Identifier: MIT
+import numpy as np
+
+from sparse_ir import FiniteTempBasisSet,\
+    TauSampling, MatsubaraSampling, finite_temp_bases
+
+def test_consistency():
+    beta = 1.0
+    wmax = 10.0
+    eps = 1e-5
+    bs = FiniteTempBasisSet(beta, wmax, eps)
+
+    basis_f, basis_b = finite_temp_bases(beta, wmax, eps)
+    smpl_tau_f = TauSampling(basis_f)
+    smpl_tau_b = TauSampling(basis_b)
+    smpl_wn_f = MatsubaraSampling(basis_f)
+    smpl_wn_b = MatsubaraSampling(basis_b)
+
+    np.testing.assert_array_equal(smpl_tau_f.sampling_points, smpl_tau_b.sampling_points)
+    np.testing.assert_array_equal(bs.smpl_tau_f.matrix.a, smpl_tau_f.matrix.a)
+    np.testing.assert_array_equal(bs.smpl_tau_b.matrix.a, smpl_tau_b.matrix.a)
+
+    np.testing.assert_array_equal(bs.smpl_wn_f.matrix.a, smpl_wn_f.matrix.a)
+    np.testing.assert_array_equal(bs.smpl_wn_b.matrix.a, smpl_wn_b.matrix.a)


### PR DESCRIPTION
In practical calculations, we construct fermion & bosonic bases and create sparse sampling objects for tau and Matsubara space. This is a bit cumbersome.

The new class provides a container of fermion and bosonic IR bases and the associated sampling objects.
The logistic kernel is used.