### PR TITLE
Added accuracy as attribute to basis

### DIFF
--- a/src/sparse_ir/basis.py
+++ b/src/sparse_ir/basis.py
@@ -85,18 +85,10 @@ class IRBasis:
         else:
             u, s, v = sve_result
             if u.shape != s.shape or s.shape != v.shape:
-                raise ValueError("mismatched shapes in SVE")
-
-        # HACK: Determine eps estimate from singular values and set it slightly
-        # larger but close to s_lmax / s_0, if it is not set. This might lead
-        # to different basis sizes/inconsistencies.
-        if eps is None:
-            eps = s[-1] / s[0]
-            pwr = np.round(np.log10(eps))
-            eps = np.floor(eps * 10**(-pwr+1)) * 10**(pwr-1)
+                raise ValueError("mismatched shapes in SVE")     
 
         self._statistics = statistics
-        self._eps = eps
+        self._accuracy = s[-1] / s[0]
 
         # The radius of convergence of the asymptotic expansion is Lambda/2,
         # so for significantly larger frequencies we use the asymptotics,
@@ -142,9 +134,9 @@ class IRBasis:
         return None
 
     @property
-    def eps(self):
-        """Relative cutoff for the singular values"""
-        return self._eps
+    def accuracy(self):
+        """Accuracy of singular value cutoff"""
+        return self._accuracy
 
     @property
     def size(self):
@@ -270,7 +262,7 @@ class FiniteTempBasis:
 
         self._statistics = statistics
         self._beta = beta
-        self._eps = eps
+        self._accuracy = s[-1] / s[0]
 
         # The polynomials are scaled to the new variables by transforming the
         # knots according to: tau = beta/2 * (x + 1), w = wmax * y.  Scaling
@@ -326,9 +318,9 @@ class FiniteTempBasis:
         return self.kernel.lambda_ / self._beta
 
     @property
-    def eps(self):
-        """Relative cutoff for the singular values"""
-        return self._eps
+    def accuracy(self):
+        """Accuracy of singular value cutoff"""
+        return self._accuracy
 
     @property
     def size(self):

--- a/src/sparse_ir/basis.py
+++ b/src/sparse_ir/basis.py
@@ -93,7 +93,7 @@ class IRBasis:
         if eps is None:
             eps = s[-1] / s[0]
             pwr = np.round(np.log10(eps))
-            eps = np.ceil(eps * 10**(-pwr+1)) * 10**(pwr-1)
+            eps = np.floor(eps * 10**(-pwr+1)) * 10**(pwr-1)
 
         self._statistics = statistics
         self._eps = eps
@@ -266,7 +266,7 @@ class FiniteTempBasis:
         if eps is None:
             eps = s[-1] / s[0]
             pwr = np.round(np.log10(eps))
-            eps = np.ceil(eps * 10**(-pwr+1)) * 10**(pwr-1)
+            eps = np.floor(eps * 10**(-pwr+1)) * 10**(pwr-1)
 
         self._statistics = statistics
         self._beta = beta

--- a/src/sparse_ir/basis.py
+++ b/src/sparse_ir/basis.py
@@ -255,6 +255,11 @@ class FiniteTempBasis:
             if u.shape != s.shape or s.shape != v.shape:
                 raise ValueError("mismatched shapes in SVE")
 
+        if u.xmin != -1 or u.xmax != 1:
+            raise RuntimeError("u must be defined in the reduced variable.")
+
+        self._sve_result = sve_result
+
         # HACK: Determine eps estimate from singular values and set it slightly
         # larger but close to s_lmax / s_0, if it is not set. This might lead
         # to different basis sizes/inconsistencies.
@@ -337,7 +342,7 @@ class FiniteTempBasis:
 
     @property
     def sve_result(self):
-        return self.u, self.s, self.v
+        return self._sve_result
 
     def default_tau_sampling_points(self):
         """Default sampling points on the imaginary time/x axis"""

--- a/src/sparse_ir/basis.py
+++ b/src/sparse_ir/basis.py
@@ -72,18 +72,31 @@ class IRBasis:
         if not (lambda_ >= 0):
             raise ValueError("kernel cutoff lambda must be non-negative")
 
+        if eps is None and sve_result is None and not sve.HAVE_XPREC:
+            warn("xprec package is not available:\n"
+                 "expect single precision (1.5e-8) only as both cutoff and\n"
+                 "accuracy of the basis functions")
+
+        # Calculate basis functions from truncated singular value expansion
         self.kernel = _get_kernel(statistics, lambda_, kernel)
         if sve_result is None:
-            u, s, v = sve.compute(self.kernel, eps)
+            sve_result = sve.compute(self.kernel, eps)
+            u, s, v = sve_result
         else:
             u, s, v = sve_result
             if u.shape != s.shape or s.shape != v.shape:
                 raise ValueError("mismatched shapes in SVE")
 
-        if eps is None and sve_result is None and not sve.HAVE_XPREC:
-            warn("xprec package is not available:\n"
-                 "expect single precision (1.5e-8) only as both cutoff and\n"
-                 "accuracy of the basis functions")
+        # HACK: Determine eps estimate from singular values and set it slightly
+        # larger but close to s_lmax / s_0, if it is not set. This might lead
+        # to different basis sizes/inconsistencies.
+        if eps is None:
+            eps = s[-1] / s[0]
+            pwr = np.round(np.log10(eps))
+            eps = np.ceil(eps * 10**(-pwr+1)) * 10**(pwr-1)
+
+        self._statistics = statistics
+        self._eps = eps
 
         # The radius of convergence of the asymptotic expansion is Lambda/2,
         # so for significantly larger frequencies we use the asymptotics,
@@ -96,7 +109,6 @@ class IRBasis:
         roots_ = v[-1].roots()
         self.sampling_points_v = np.hstack(
             (v.xmin, 0.5 * (roots_[0:-1] + roots_[1:]), v.xmax))
-        self.statistics = statistics
 
     def __getitem__(self, index):
         """Return basis functions/singular values for given index/indices.
@@ -106,22 +118,18 @@ class IRBasis:
         """
         sve_result = self.u[index], self.s[index], self.v[index]
         return self.__class__(self.statistics, self.lambda_,
-                              kernel=self.kernel, sve_result=sve_result)
+                              eps=self.eps, kernel=self.kernel,
+                              sve_result=sve_result)
+
+    @property
+    def statistics(self):
+        """Quantum statistic"""
+        return self._statistics
 
     @property
     def lambda_(self):
         """Basis cutoff parameter Λ = β * ωmax"""
         return self.kernel.lambda_
-
-    @property
-    def size(self):
-        """Number of basis functions / singular values."""
-        return self.u.size
-
-    @property
-    def shape(self):
-        """Shape of the basis function set"""
-        return self.u.shape
 
     @property
     def beta(self):
@@ -130,8 +138,23 @@ class IRBasis:
 
     @property
     def wmax(self):
-        """Frequency cutoff (this is `None` because unscaled basis)"""
+        """Real frequency cutoff (this is `None` because unscaled basis)"""
         return None
+
+    @property
+    def eps(self):
+        """Relative cutoff for the singular values"""
+        return self._eps
+
+    @property
+    def size(self):
+        """Number of basis functions / singular values"""
+        return self.u.size
+
+    @property
+    def shape(self):
+        """Shape of the basis function set"""
+        return self.u.shape
 
     @property
     def sve_result(self):
@@ -217,27 +240,37 @@ class FiniteTempBasis:
         if not (wmax >= 0):
             raise ValueError("frequency cutoff must be non-negative")
 
-        self.kernel = _get_kernel(statistics, beta * wmax, kernel)
-        if sve_result is None:
-            u, s, v = sve.compute(self.kernel, eps)
-        else:
-            u, s, v = sve_result
-            if u.shape != s.shape or s.shape != v.shape:
-                raise ValueError("mismatched shapes in SVE")
-
-        self.sve_result = u, s, v
-        self.statistics = statistics
-        self.beta = beta
-
         if eps is None and sve_result is None and not sve.HAVE_XPREC:
             warn("xprec package is not available:\n"
                  "expect single precision (1.5e-8) only as both cutoff and\n"
                  "accuracy of the basis functions")
 
+        # Calculate basis functions from truncated singular value expansion
+        self.kernel = _get_kernel(statistics, beta * wmax, kernel)
+        if sve_result is None:
+            sve_result = sve.compute(self.kernel, eps)
+            u, s, v = sve_result
+        else:
+            u, s, v = sve_result
+            if u.shape != s.shape or s.shape != v.shape:
+                raise ValueError("mismatched shapes in SVE")
+
+        # HACK: Determine eps estimate from singular values and set it slightly
+        # larger but close to s_lmax / s_0, if it is not set. This might lead
+        # to different basis sizes/inconsistencies.
+        if eps is None:
+            eps = s[-1] / s[0]
+            pwr = np.round(np.log10(eps))
+            eps = np.ceil(eps * 10**(-pwr+1)) * 10**(pwr-1)
+
+        self._statistics = statistics
+        self._beta = beta
+        self._eps = eps
+
         # The polynomials are scaled to the new variables by transforming the
         # knots according to: tau = beta/2 * (x + 1), w = wmax * y.  Scaling
         # the data is not necessary as the normalization is inferred.
-        wmax = self.kernel.lambda_ / self.beta
+        wmax = self.kernel.lambda_ / self._beta
         self.u = u.__class__(u.data, beta/2 * (u.knots + 1), beta/2 * u.dx, u.symm)
         self.v = v.__class__(v.data, wmax * v.knots, wmax * v.dx, v.symm)
 
@@ -264,22 +297,47 @@ class FiniteTempBasis:
         u, s, v = self.sve_result
         sve_result = u[index], s[index], v[index]
         return self.__class__(self.statistics, self.beta, self.wmax,
-                              kernel=self.kernel, sve_result=sve_result)
+                              eps=self.eps, kernel=self.kernel,
+                              sve_result=sve_result)
+
+    @property
+    def statistics(self):
+        """Quantum statistic"""
+        return self._statistics
+
+    @property
+    def lambda_(self):
+        """Basis cutoff parameter Λ = β * ωmax"""
+        return self.kernel.lambda_
+
+    @property
+    def beta(self):
+        """Inverse temperature (this is `None` because unscaled basis)"""
+        return self._beta
 
     @property
     def wmax(self):
-        """Cutoff in real frequency."""
-        return self.kernel.lambda_ / self.beta
+        """Real frequency cutoff"""
+        return self.kernel.lambda_ / self._beta
+
+    @property
+    def eps(self):
+        """Relative cutoff for the singular values"""
+        return self._eps
 
     @property
     def size(self):
-        """Number of basis functions / singular values."""
+        """Number of basis functions / singular values"""
         return self.u.size
 
     @property
     def shape(self):
         """Shape of the basis function set"""
         return self.u.shape
+
+    @property
+    def sve_result(self):
+        return self.u, self.s, self.v
 
     def default_tau_sampling_points(self):
         """Default sampling points on the imaginary time/x axis"""
@@ -310,8 +368,8 @@ def finite_temp_bases(
     """
     if sve_result is None:
         sve_result = sve.compute(_kernel.LogisticKernel(beta*wmax), eps)
-    basis_f = FiniteTempBasis("F", beta, wmax, eps, sve_result=sve_result)
-    basis_b = FiniteTempBasis("B", beta, wmax, eps, sve_result=sve_result)
+    basis_f = FiniteTempBasis("F", beta, wmax, eps=eps, sve_result=sve_result)
+    basis_b = FiniteTempBasis("B", beta, wmax, eps=eps, sve_result=sve_result)
     return basis_f, basis_b
 
 

--- a/src/sparse_ir/basis_set.py
+++ b/src/sparse_ir/basis_set.py
@@ -36,7 +36,7 @@ class FiniteTempBasisSet:
         sve_result (tuple of three ndarray objects):
             Results of SVE
     """
-    def __init__(self, beta, wmax, eps, sve_result=None):
+    def __init__(self, beta, wmax, eps=None, sve_result=None):
         """
         Create basis sets for fermion and boson and
         associated sampling objects.
@@ -50,8 +50,6 @@ class FiniteTempBasisSet:
             self.basis_f = FiniteTempBasis("F", beta, wmax, eps, sve_result=sve_result)
             self.basis_b = FiniteTempBasis("B", beta, wmax, eps, sve_result=sve_result)
 
-        self.eps = eps
-
         # Tau sampling
         self.smpl_tau_f = TauSampling(self.basis_f)
         self.smpl_tau_b = TauSampling(self.basis_b)
@@ -61,10 +59,16 @@ class FiniteTempBasisSet:
         self.smpl_wn_b = MatsubaraSampling(self.basis_b)
 
     @property
+    def lambda_(self): return self.basis_f.beta.lambda_
+
+    @property
     def beta(self): return self.basis_f.beta
 
     @property
     def wmax(self): return self.basis_f.wmax
+
+    @property
+    def eps(self): return self.basis_f.eps
 
     @property
     def sve_result(self): return self.basis_f.sve_result

--- a/src/sparse_ir/basis_set.py
+++ b/src/sparse_ir/basis_set.py
@@ -68,7 +68,7 @@ class FiniteTempBasisSet:
     def wmax(self): return self.basis_f.wmax
 
     @property
-    def eps(self): return self.basis_f.eps
+    def accuracy(self): return self.basis_f.accuracy
 
     @property
     def sve_result(self): return self.basis_f.sve_result


### PR DESCRIPTION
Added relative tolerance `eps > s_lmax / s_0` as an attribute to the basis class (and inheriting it in basis_set). It is a solution to issue #19, although the way of adding a value for `eps` is kinda hacky if `eps=None` is the input. Like this, it should be more or less consistent (instead of just using `eps = s[-1] / s[0]`, since it can lead to larger basis sizes using this calculated eps).
In the future, adding some SVE_results class might be useful for doing this consistently.

In adding the tolerance, I also cleaned up the attributes/properties of IRbasis and FiniteTempBasis.