### PR TITLE
Correct cleanup of #20, #21

### DIFF
--- a/src/sparse_ir/basis.py
+++ b/src/sparse_ir/basis.py
@@ -72,18 +72,23 @@ class IRBasis:
         if not (lambda_ >= 0):
             raise ValueError("kernel cutoff lambda must be non-negative")
 
+        if eps is None and sve_result is None and not sve.HAVE_XPREC:
+            warn("xprec package is not available:\n"
+                 "expect single precision (1.5e-8) only as both cutoff and\n"
+                 "accuracy of the basis functions")
+
+        # Calculate basis functions from truncated singular value expansion
         self.kernel = _get_kernel(statistics, lambda_, kernel)
         if sve_result is None:
-            u, s, v = sve.compute(self.kernel, eps)
+            sve_result = sve.compute(self.kernel, eps)
+            u, s, v = sve_result
         else:
             u, s, v = sve_result
             if u.shape != s.shape or s.shape != v.shape:
                 raise ValueError("mismatched shapes in SVE")
 
-        if eps is None and sve_result is None and not sve.HAVE_XPREC:
-            warn("xprec package is not available:\n"
-                 "expect single precision (1.5e-8) only as both cutoff and\n"
-                 "accuracy of the basis functions")
+        self._statistics = statistics
+        self._accuracy = s[-1] / s[0]
 
         # The radius of convergence of the asymptotic expansion is Lambda/2,
         # so for significantly larger frequencies we use the asymptotics,
@@ -96,7 +101,6 @@ class IRBasis:
         roots_ = v[-1].roots()
         self.sampling_points_v = np.hstack(
             (v.xmin, 0.5 * (roots_[0:-1] + roots_[1:]), v.xmax))
-        self._statistics = statistics
 
     def __getitem__(self, index):
         """Return basis functions/singular values for given index/indices.
@@ -119,24 +123,29 @@ class IRBasis:
         return self.kernel.lambda_
 
     @property
-    def size(self):
-        """Number of basis functions / singular values."""
-        return self.u.size
-
-    @property
-    def shape(self):
-        """Shape of the basis function set"""
-        return self.u.shape
-
-    @property
     def beta(self):
         """Inverse temperature (this is `None` because unscaled basis)"""
         return None
 
     @property
     def wmax(self):
-        """Frequency cutoff (this is `None` because unscaled basis)"""
+        """Real frequency cutoff (this is `None` because unscaled basis)"""
         return None
+
+    @property
+    def accuracy(self):
+        """Accuracy of singular value cutoff"""
+        return self._accuracy
+
+    @property
+    def size(self):
+        """Number of basis functions / singular values"""
+        return self.u.size
+
+    @property
+    def shape(self):
+        """Shape of the basis function set"""
+        return self.u.shape
 
     @property
     def sve_result(self):
@@ -222,27 +231,33 @@ class FiniteTempBasis:
         if not (wmax >= 0):
             raise ValueError("frequency cutoff must be non-negative")
 
-        self.kernel = _get_kernel(statistics, beta * wmax, kernel)
-        if sve_result is None:
-            u, s, v = sve.compute(self.kernel, eps)
-        else:
-            u, s, v = sve_result
-            if u.shape != s.shape or s.shape != v.shape:
-                raise ValueError("mismatched shapes in SVE")
-
-        self._sve_result = sve_result
-        self._statistics = statistics
-        self._beta = beta
-        self._accuracy = s[-1] / s[0]
         if eps is None and sve_result is None and not sve.HAVE_XPREC:
             warn("xprec package is not available:\n"
                  "expect single precision (1.5e-8) only as both cutoff and\n"
                  "accuracy of the basis functions")
 
+        # Calculate basis functions from truncated singular value expansion
+        self.kernel = _get_kernel(statistics, beta * wmax, kernel)
+        if sve_result is None:
+            sve_result = sve.compute(self.kernel, eps)
+            u, s, v = sve_result
+        else:
+            u, s, v = sve_result
+            if u.shape != s.shape or s.shape != v.shape:
+                raise ValueError("mismatched shapes in SVE")
+
+        if u.xmin != -1 or u.xmax != 1:
+            raise RuntimeError("u must be defined in the reduced variable.")
+
+        self._sve_result = sve_result
+        self._statistics = statistics
+        self._beta = beta
+        self._accuracy = s[-1] / s[0]
+
         # The polynomials are scaled to the new variables by transforming the
         # knots according to: tau = beta/2 * (x + 1), w = wmax * y.  Scaling
         # the data is not necessary as the normalization is inferred.
-        wmax = self.kernel.lambda_ / self.beta
+        wmax = self.kernel.lambda_ / self._beta
         self.u = u.__class__(u.data, beta/2 * (u.knots + 1), beta/2 * u.dx, u.symm)
         self.v = v.__class__(v.data, wmax * v.knots, wmax * v.dx, v.symm)
 
@@ -288,22 +303,27 @@ class FiniteTempBasis:
 
     @property
     def wmax(self):
-        """Cutoff in real frequency."""
-        return self.kernel.lambda_ / self.beta
+        """Real frequency cutoff"""
+        return self.kernel.lambda_ / self._beta
 
     @property
-    def sve_result(self):
-        return self._sve_result
+    def accuracy(self):
+        """Accuracy of singular value cutoff"""
+        return self._accuracy
 
     @property
     def size(self):
-        """Number of basis functions / singular values."""
+        """Number of basis functions / singular values"""
         return self.u.size
 
     @property
     def shape(self):
         """Shape of the basis function set"""
         return self.u.shape
+
+    @property
+    def sve_result(self):
+        return self._sve_result
 
     def default_tau_sampling_points(self):
         """Default sampling points on the imaginary time/x axis"""

--- a/src/sparse_ir/basis_set.py
+++ b/src/sparse_ir/basis_set.py
@@ -36,7 +36,7 @@ class FiniteTempBasisSet:
         sve_result (tuple of three ndarray objects):
             Results of SVE
     """
-    def __init__(self, beta, wmax, eps, sve_result=None):
+    def __init__(self, beta, wmax, eps=None, sve_result=None):
         """
         Create basis sets for fermion and boson and
         associated sampling objects.
@@ -50,8 +50,6 @@ class FiniteTempBasisSet:
             self.basis_f = FiniteTempBasis("F", beta, wmax, eps, sve_result=sve_result)
             self.basis_b = FiniteTempBasis("B", beta, wmax, eps, sve_result=sve_result)
 
-        self.eps = eps
-
         # Tau sampling
         self.smpl_tau_f = TauSampling(self.basis_f)
         self.smpl_tau_b = TauSampling(self.basis_b)
@@ -61,10 +59,16 @@ class FiniteTempBasisSet:
         self.smpl_wn_b = MatsubaraSampling(self.basis_b)
 
     @property
+    def lambda_(self): return self.basis_f.beta.lambda_
+
+    @property
     def beta(self): return self.basis_f.beta
 
     @property
     def wmax(self): return self.basis_f.wmax
+
+    @property
+    def accuracy(self): return self.basis_f.accuracy
 
     @property
     def sve_result(self): return self.basis_f.sve_result


### PR DESCRIPTION
PR #21 did only contain the last commit of the previous fork that was meant to cleanup PR #20. However, it did not contain any real changes to the code and just resolving the conflicts did not include them either.
For instance, the property `accuracy` was not included or `eps` was not removed from `basis_set.py`. This should now work and all tests should run through.

I am sorry for the inconvenience². 