### PR TITLE
Fix a bug in PiecewiseLegendreFT (as well as some inconsequential typos)

### DIFF
--- a/src/sparse_ir/basis.py
+++ b/src/sparse_ir/basis.py
@@ -172,7 +172,7 @@ class IRBasis:
 class FiniteTempBasis:
     """Intermediate representation (IR) basis for given temperature.
 
-    For a continuation kernel from real frequencies, ω ∈ [-wmax, wmax], to
+    For a continuation kernel from real frequencies, ω ∈ [-ωmax, ωmax], to
     imaginary time, τ ∈ [0, beta], this class stores the truncated singular
     value expansion or IR basis::
 
@@ -214,7 +214,7 @@ class FiniteTempBasis:
             function, a slice or a subset `l`, you can use ``uhat[l]``.
 
         s:
-            vector of singular values of the continuation kernel
+            Vector of singular values of the continuation kernel
 
         v (sparse_ir.poly.PiecewiseLegendrePoly):
             Set of IR basis functions on the real frequency (`w`) axis.

--- a/src/sparse_ir/basis_set.py
+++ b/src/sparse_ir/basis_set.py
@@ -3,10 +3,10 @@ from .sampling import TauSampling, MatsubaraSampling
 
 
 class FiniteTempBasisSet:
-    """Class for holding IR bases and sparse-sampling objects
+    """Class for holding IR bases and sparse-sampling objects.
 
-    An object of this class holds IR bases for fermion and bosons
-    and associated sparse-sampling objects
+    An object of this class holds IR bases for fermions and bosons
+    and associated sparse-sampling objects.
 
     Attributes:
         basis_f (FiniteTempBasis):

--- a/src/sparse_ir/sve.py
+++ b/src/sparse_ir/sve.py
@@ -15,7 +15,7 @@ def compute(K, eps=None, n_sv=None, n_gauss=None, dtype=float, work_dtype=None,
             sve_strat=None, svd_strat=None):
     """Perform truncated singular value expansion of a kernel.
 
-    Perform a truncated singular value expansion (SVE) of a integral
+    Perform a truncated singular value expansion (SVE) of an integral
     kernel ``K : [xmin, xmax] x [ymin, ymax] -> R``:
 
         K(x, y) == sum(s[l] * u[l](x) * v[l](y) for l in (0, 1, 2, ...)),
@@ -23,7 +23,7 @@ def compute(K, eps=None, n_sv=None, n_gauss=None, dtype=float, work_dtype=None,
     where ``s[l]`` are the singular values, which are ordered in non-increasing
     fashion, ``u[l](x)`` are the left singular functions, which form an
     orthonormal system on ``[xmin, xmax]``, and ``v[l](y)`` are the right
-    singular functions, which for an orthonormal system on ``[ymin, ymax]``
+    singular functions, which form an orthonormal system on ``[ymin, ymax]``.
 
     The SVE is mapped onto the singular value decomposition (SVD) of a matrix
     by expanding the kernel in piecewise Legendre polynomials (by default by
@@ -32,19 +32,19 @@ def compute(K, eps=None, n_sv=None, n_gauss=None, dtype=float, work_dtype=None,
     Arguments:
 
       - ``K``: Integral kernel to take SVE from
-      - ``eps``:  Relative cutoff for the singular values.  Defaults to double
+      - ``eps``:  Relative cutoff for the singular values. Defaults to double
         precision (2.2e-16) if the xprec package is available, and 1.5e-8
         otherwise.
-      - ``n_sv``: Maximum basis size.  If given, only at most the ``n_sv`` most
+      - ``n_sv``: Maximum basis size. If given, only at most the ``n_sv`` most
         significant singular values and associated singular functions are
         returned.
-      - ``n_gauss``: Order of Legendre polynomials.  Defaults to hinted value
+      - ``n_gauss``: Order of Legendre polynomials. Defaults to hinted value
         by the kernel.
       - ``dtype``: Data type of the result.
-      - ``work_dtype``: Working data type.  Defaults to a data type with
+      - ``work_dtype``: Working data type. Defaults to a data type with
         machine epsilon of at least ``eps**2``, or otherwise most accurate data
         type available.
-      - ``sve_strat``: SVE to SVD translation strategy.  Defaults to SamplingSVE.
+      - ``sve_strat``: SVE to SVD translation strategy. Defaults to SamplingSVE.
       - ``svd_strat``: SVD solver. Defaults to fast (ID/RRQR) based solution
          when accuracy goals are moderate, and more accurate Jacobi-based
          algorithm otherwise.

--- a/test/test_matsubara.py
+++ b/test/test_matsubara.py
@@ -22,7 +22,7 @@ results computed by using unl.
 def test_single_pole(sve_logistic, stat, lambda_):
     wmax = 1.0
     pole = 0.1 * wmax
-    beta = lambda_/wmax
+    beta = lambda_ / wmax
     sve_result = sve_logistic[lambda_]
     basis = FiniteTempBasis(stat, beta, wmax, eps, sve_result=sve_result)
 

--- a/test/test_poly.py
+++ b/test/test_poly.py
@@ -35,9 +35,9 @@ def test_eval(sve_logistic):
     l = s.size
 
     # evaluate
-    np.testing.assert_array_almost_equal_nulp(
+    np.testing.assert_array_equal(
             u(0.4), [u[i](0.4) for i in range(l)])
-    np.testing.assert_array_almost_equal_nulp(
+    np.testing.assert_array_equal(
             u([0.4, -0.2]),
             [[u[i](x) for x in (0.4, -0.2)] for i in range(l)])
 
@@ -47,7 +47,7 @@ def test_broadcast(sve_logistic):
 
     x = [0.3, 0.5]
     l = [2, 7]
-    np.testing.assert_array_almost_equal_nulp(
+    np.testing.assert_array_equal(
             u.value(l, x), [u[ll](xx) for (ll, xx) in zip(l, x)])
 
 
@@ -59,7 +59,7 @@ def test_matrix_hat(sve_logistic):
     result = uhat(n.reshape(3, 2))
     result_iter = uhat(n).reshape(-1, 3, 2)
     assert result.shape == result_iter.shape
-    np.testing.assert_array_almost_equal_nulp(result, result_iter)
+    np.testing.assert_array_equal(result, result_iter)
 
 
 @pytest.mark.parametrize("lambda_, atol", [(42, 1e-13), (1E+4, 1e-13)])
@@ -68,7 +68,6 @@ def test_overlap(sve_logistic, lambda_, atol):
 
     # Keep only even number of polynomials
     u, s, v = u[:2*(s.size//2)], s[:2*(s.size//2)], v[:2*(s.size//2)]
-    npoly = s.size
 
     np.testing.assert_allclose(u[0].overlap(u[0]), 1, rtol=0, atol=atol)
 

--- a/test/test_sampling.py
+++ b/test/test_sampling.py
@@ -75,7 +75,7 @@ def test_tau_noise(sve_logistic, stat, lambda_):
     Gtau = smpl.evaluate(Gl)
 
     noise = 1e-5
-    Gtau_n = Gtau +  noise * np.linalg.norm(Gtau) * rng.randn(*Gtau.shape)
+    Gtau_n = Gtau + noise * np.linalg.norm(Gtau) * rng.randn(*Gtau.shape)
     Gl_n = smpl.fit(Gtau_n)
 
     np.testing.assert_allclose(Gl, Gl_n, atol=12 * noise * Gl_magn, rtol=0)


### PR DESCRIPTION
There was a bug rooted in `PiecewiseLegendreFT.__getitem__`.
```
>>> import numpy as np
>>> import sparse_ir
>>> basis = sparse_ir.FiniteTempBasis("B", 1e4, 1, 1e-15)
>>> n = np.array([4e5])
```
Without this PR, `basis.uhat[1](n)` gives a wrong result, i.e. different from `basis.uhat(n)[1]`.