### PR TITLE
Rename `IRBasis` -> `DimensionlessBasis`

### DIFF
--- a/doc/basis.rst
+++ b/doc/basis.rst
@@ -1,11 +1,10 @@
 IR Basis
 ========
 
-
 .. autoclass:: sparse_ir.FiniteTempBasis
     :members:
 
-.. autoclass:: sparse_ir.IRBasis
+.. autoclass:: sparse_ir.DimensionlessBasis
     :members:
 
 Piecewise polynomials

--- a/doc/kernels.rst
+++ b/doc/kernels.rst
@@ -20,7 +20,7 @@ defines two kernels:
    with w(ω)=1/ω.
 
 By default, :class:`sparse_ir.LogisticKernel` is used.
-Kernels can be fed directly into :class:`sparse_ir.IRBasis` or
+Kernels can be fed directly into :class:`sparse_ir.DimensionlessBasis` or
 :class:`sparse_ir.FiniteTempBasis` to get the intermediate representation.
 
 .. _singular value expansion: https://w.wiki/3poQ
@@ -73,10 +73,10 @@ fermionic kernel, modifying the values as needed::
         def hints(self, eps):
             return self._inner.hints(eps)
 
-You can feed this kernel now directly to :class:`sparse_ir.IRBasis`::
+You can feed this kernel now directly to :class:`sparse_ir.DimensionlessBasis`::
 
     K = GaussFKernel(10., 1.)
-    basis = sparse_ir.IRBasis(K, 'F')
+    basis = sparse_ir.DimensionlessBasis(K, 'F')
     print(basis.s)
 
 This should get you started.  For a fully-fledged and robust implementation,

--- a/src/sparse_ir/__init__.py
+++ b/src/sparse_ir/__init__.py
@@ -19,6 +19,6 @@ except ImportError:
 
 from .kernel import RegularizedBoseKernel, LogisticKernel
 from .sve import compute as compute_sve
-from .basis import IRBasis, FiniteTempBasis, finite_temp_bases
+from .basis import DimensionlessBasis, FiniteTempBasis, finite_temp_bases
 from .basis_set import FiniteTempBasisSet
 from .sampling import TauSampling, MatsubaraSampling

--- a/src/sparse_ir/adapter.py
+++ b/src/sparse_ir/adapter.py
@@ -35,7 +35,8 @@ def load(statistics, Lambda, h5file=None):
              "To squelch this warning, set WARN_ACCURACY to False.")
 
     kernel_type = {"F": LogisticKernel, "B": RegularizedBoseKernel}[statistics]
-    basis = _basis.IRBasis(statistics, float(Lambda), kernel=kernel_type(Lambda))
+    basis = _basis.DimensionlessBasis(statistics, float(Lambda),
+                                      kernel=kernel_type(Lambda))
     return Basis(statistics, Lambda, (basis.u, basis.s, basis.v))
 
 

--- a/src/sparse_ir/basis.py
+++ b/src/sparse_ir/basis.py
@@ -8,7 +8,7 @@ from . import kernel as _kernel
 from . import sve
 
 
-class IRBasis:
+class DimensionlessBasis:
     """Intermediate representation (IR) basis in reduced variables.
 
     For a continuation kernel from real frequencies, ω ∈ [-ωmax, ωmax], to
@@ -27,7 +27,7 @@ class IRBasis:
 
             # Compute IR basis suitable for fermions and β*W <= 42
             import sparse_ir
-            basis = sparse_ir.IRBasis(statistics='F', lambda_=42)
+            basis = sparse_ir.DimensionlessBasis(statistics='F', lambda_=42)
 
             # Assume spectrum is a single pole at x = 0.2, compute G(iw)
             # on the first few Matsubara frequencies

--- a/test/test_poly.py
+++ b/test/test_poly.py
@@ -23,7 +23,7 @@ def test_shape(sve_logistic):
 def test_slice(sve_logistic):
     sve_result = sve_logistic[42]
 
-    basis = sparse_ir.IRBasis('F', 42, sve_result=sve_result)
+    basis = sparse_ir.DimensionlessBasis('F', 42, sve_result=sve_result)
     assert basis[:5].size == 5
 
     basis = sparse_ir.FiniteTempBasis('F', 4.2, 10, sve_result=sve_result)

--- a/test/test_sampling.py
+++ b/test/test_sampling.py
@@ -65,7 +65,8 @@ def test_axis0():
 
 @pytest.mark.parametrize("stat, lambda_", [('B', 42), ('F', 42)])
 def test_tau_noise(sve_logistic, stat, lambda_):
-    basis = sparse_ir.IRBasis(stat, lambda_, sve_result=sve_logistic[lambda_])
+    basis = sparse_ir.DimensionlessBasis(stat, lambda_,
+                                         sve_result=sve_logistic[lambda_])
     smpl = sparse_ir.TauSampling(basis)
     rng = np.random.RandomState(4711)
 
@@ -83,7 +84,8 @@ def test_tau_noise(sve_logistic, stat, lambda_):
 
 @pytest.mark.parametrize("stat, lambda_", [('B', 42), ('F', 42)])
 def test_wn_noise(sve_logistic, stat, lambda_):
-    basis = sparse_ir.IRBasis(stat, lambda_, sve_result=sve_logistic[lambda_])
+    basis = sparse_ir.DimensionlessBasis(stat, lambda_,
+                                         sve_result=sve_logistic[lambda_])
     smpl = sparse_ir.MatsubaraSampling(basis)
     rng = np.random.RandomState(4711)
 

--- a/test/test_sve.py
+++ b/test/test_sve.py
@@ -25,14 +25,16 @@ def _check_smooth(u, s, uscale, fudge_factor):
 
 @pytest.mark.parametrize("lambda_", [10, 42, 10_000])
 def test_smooth(sve_logistic, lambda_):
-    basis = sparse_ir.IRBasis('F', lambda_, sve_result=sve_logistic[lambda_])
+    basis = sparse_ir.DimensionlessBasis('F', lambda_,
+                                         sve_result=sve_logistic[lambda_])
     _check_smooth(basis.u, basis.s, 2*basis.u(1).max(), 24)
     _check_smooth(basis.v, basis.s, 50, 20)
 
 
 @pytest.mark.parametrize("lambda_", [10, 42, 10_000])
 def test_num_roots_u(sve_logistic, lambda_):
-    basis = sparse_ir.IRBasis('F', lambda_, sve_result=sve_logistic[lambda_])
+    basis = sparse_ir.DimensionlessBasis('F', lambda_,
+                                         sve_result=sve_logistic[lambda_])
     for i in range(basis.u.size):
         ui_roots = basis.u[i].roots()
         assert ui_roots.size == i
@@ -41,7 +43,8 @@ def test_num_roots_u(sve_logistic, lambda_):
 @pytest.mark.parametrize("stat", ['F', 'B'])
 @pytest.mark.parametrize("lambda_", [10, 42, 10_000])
 def test_num_roots_uhat(sve_logistic, stat, lambda_):
-    basis = sparse_ir.IRBasis(stat, lambda_, sve_result=sve_logistic[lambda_])
+    basis = sparse_ir.DimensionlessBasis(stat, lambda_,
+                                         sve_result=sve_logistic[lambda_])
     for i in [0, 1, 7, 10]:
         x0 = basis.uhat[i].extrema()
         assert i + 1 <= x0.size <= i + 2


### PR DESCRIPTION
As @nikwitt points out: `IRBasis` is a weird name, `DimensionlessBasis` is probably better.

This also introduces an abstract base class for both.