### PR TITLE
Refactor SVE

### DIFF
--- a/doc/basis.rst
+++ b/doc/basis.rst
@@ -4,9 +4,6 @@ IR Basis
 .. autoclass:: sparse_ir.FiniteTempBasis
     :members:
 
-.. autoclass:: sparse_ir.DimensionlessBasis
-    :members:
-
 Piecewise polynomials
 ---------------------
 

--- a/doc/composite.rst
+++ b/doc/composite.rst
@@ -1,6 +1,10 @@
 Composite and augmented bases
 =============================
 
+.. autoclass:: sparse_ir.abstract.AbstractBasis
+    :members:
+
+
 Composite basis
 ---------------
 .. automodule:: sparse_ir.composite

--- a/doc/kernels.rst
+++ b/doc/kernels.rst
@@ -28,10 +28,6 @@ get the intermediate representation.
 
 Predefined kernels
 ------------------
-.. autoclass:: sparse_ir.LaplaceKernel
-    :members:
-    :special-members: __call__
-
 .. autoclass:: sparse_ir.LogisticKernel
     :members:
     :special-members: __call__
@@ -59,7 +55,7 @@ fermionic kernel, modifying the values as needed::
 
     class KernelFGauss(sparse_ir.kernel.AbstractKernel):
         def __init__(self, lambda_, std):
-            self._inner = sparse_ir.LaplaceKernel(lambda_)
+            self._inner = sparse_ir.LogisticKernel(lambda_)
             self.lambda_ = lambda_
             self.std = std
 

--- a/doc/kernels.rst
+++ b/doc/kernels.rst
@@ -20,8 +20,8 @@ defines two kernels:
    with w(ω)=1/ω.
 
 By default, :class:`sparse_ir.LogisticKernel` is used.
-Kernels can be fed directly into :class:`sparse_ir.DimensionlessBasis` or
-:class:`sparse_ir.FiniteTempBasis` to get the intermediate representation.
+Kernels can be fed directly into :class:`sparse_ir.FiniteTempBasis` to
+get the intermediate representation.
 
 .. _singular value expansion: https://w.wiki/3poQ
 
@@ -73,10 +73,10 @@ fermionic kernel, modifying the values as needed::
         def hints(self, eps):
             return self._inner.hints(eps)
 
-You can feed this kernel now directly to :class:`sparse_ir.DimensionlessBasis`::
+You can feed this kernel now directly to :class:`sparse_ir.FiniteTempBasis`::
 
     K = GaussFKernel(10., 1.)
-    basis = sparse_ir.DimensionlessBasis(K, 'F')
+    basis = sparse_ir.FiniteTempBasis(K, 'F')
     print(basis.s)
 
 This should get you started.  For a fully-fledged and robust implementation,

--- a/doc/sve.rst
+++ b/doc/sve.rst
@@ -14,9 +14,3 @@ Singular value decomposition
 
 .. automodule:: sparse_ir.svd
     :members:
-
-Gauss quadrature
-----------------
-
-.. automodule:: sparse_ir.gauss
-    :members:

--- a/src/sparse_ir/__init__.py
+++ b/src/sparse_ir/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
     pass
 
 from .kernel import RegularizedBoseKernel, LogisticKernel
-from .sve import compute as compute_sve
-from .basis import DimensionlessBasis, FiniteTempBasis, finite_temp_bases
+from .sve import compute as compute_sve, SVEResult
+from .basis import FiniteTempBasis, finite_temp_bases
 from .basis_set import FiniteTempBasisSet
 from .sampling import TauSampling, MatsubaraSampling

--- a/src/sparse_ir/adapter.py
+++ b/src/sparse_ir/adapter.py
@@ -18,7 +18,7 @@ setting `WARN_ACCURACY` to false.
 import numpy as _np
 from warnings import warn as _warn
 
-from . import basis as _basis
+from . import sve as _sve
 from . import poly as _poly
 from . import kernel as _kernel
 
@@ -39,14 +39,14 @@ def load(statistics, Lambda, h5file=None):
 
     kernel_type = {"F": _kernel.LogisticKernel,
                    "B": _kernel.RegularizedBoseKernel}[statistics]
-    basis = _basis.DimensionlessBasis(statistics, float(Lambda),
-                                      kernel=kernel_type(Lambda))
-    return Basis(statistics, Lambda, (basis.u, basis.s, basis.v))
+    kernel = kernel_type(float(Lambda))
+    sve_result = _sve.compute(kernel)
+    return Basis(statistics, Lambda, sve_result)
 
 
 class Basis:
     def __init__(self, statistics, Lambda, sve_result):
-        u, s, v = sve_result
+        u, s, v = sve_result.part()
         self._statistics = statistics
         self._Lambda = Lambda
         self._u = u

--- a/src/sparse_ir/basis.py
+++ b/src/sparse_ir/basis.py
@@ -144,9 +144,9 @@ class FiniteTempBasis(abstract.AbstractBasis):
     def rescale(self, new_beta):
         """Return a basis for different temperature.
 
-        Uses the same kernel, but a different temperature.  Note that this
-        implies a different UV cutoff `wmax`, since `lambda_ == beta * wmax`
-        stays constant.
+        Uses the same kernel with the same ``eps``, but a different
+        temperature.  Note that this implies a different UV cutoff ``wmax``,
+        since ``lambda_ == beta * wmax`` stays constant.
         """
         new_wmax = self._kernel.lambda_ / new_beta
         return FiniteTempBasis(self._statistics, new_beta, new_wmax, None,

--- a/src/sparse_ir/kernel.py
+++ b/src/sparse_ir/kernel.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2020-2022 Markus Wallerberger, Hiroshi Shinaoka, and others
 # SPDX-License-Identifier: MIT
 import numpy as np
-from warnings import warn
 from typing import Callable
 
 
@@ -200,8 +199,8 @@ class LogisticKernel(AbstractKernel):
         """
         Return the weight function for given statistics.
 
-        Fermion: w(x) = 1
-        Boson: w(y) = 1/tanh(Λ*y/2)
+         - Fermion: `w(x) == 1`
+         - Boson: `w(y) == 1/tanh(Λ*y/2)`
         """
         if statistics not in "FB":
             raise ValueError("invalid value of statistics argument")

--- a/src/sparse_ir/sve.py
+++ b/src/sparse_ir/sve.py
@@ -16,7 +16,7 @@ def compute(K, eps=None, cutoff=None, n_sv=None, n_gauss=None, dtype=float,
     """Perform truncated singular value expansion of a kernel.
 
     Perform a truncated singular value expansion (SVE) of an integral
-    kernel ``K : [xmin, xmax] x [ymin, ymax] -> R``:
+    kernel ``K : [xmin, xmax] x [ymin, ymax] -> R``::
 
         K(x, y) == sum(s[l] * u[l](x) * v[l](y) for l in (0, 1, 2, ...)),
 
@@ -44,10 +44,10 @@ def compute(K, eps=None, cutoff=None, n_sv=None, n_gauss=None, dtype=float,
             machine epsilon of ``cutoff`` is required to satisfy this.
             Defaults to a small multiple of the machine epsilon.
 
-            Note that `cutoff` and `eps` serve distinct purposes. `cutoff`
+            Note that ``cutoff`` and ``eps`` serve distinct purposes. ``cutoff``
             reprsents the accuracy to which the kernel is reproduced, whereas
-            `eps` is the accuracy to which the singular values and vectors are
-            guaranteed.
+            ``eps`` is the accuracy to which the singular values and vectors
+            are guaranteed.
         n_sv (int):
             Maximum basis size. If given, only at most the ``n_sv`` most
             significant singular values and associated singular functions are
@@ -58,7 +58,7 @@ def compute(K, eps=None, cutoff=None, n_sv=None, n_gauss=None, dtype=float,
             Data type of the result.
         work_dtype (np.dtype):
             Working data type. Defaults to a data type with machine epsilon of
-            at most ``eps**2`` and at most  ``cutoff`, or otherwise most
+            at most ``eps**2`` and at most  ``cutoff``, or otherwise most
             accurate data type available.
         sve_strat (AbstractSVE):
             SVE to SVD translation strategy. Defaults to ``SamplingSVE``,
@@ -147,12 +147,12 @@ class SamplingSVE(AbstractSVE):
     sets of Gauss quadrature rules: ``(x, wx)`` and ``(y, wy)`` and
     approximating the integrals in the SVE equations by finite sums.  This
     implies that the singular values of the SVE are well-approximated by the
-    singular values of the following matrix:
+    singular values of the following matrix::
 
         A[i, j] = sqrt(wx[i]) * K(x[i], y[j]) * sqrt(wy[j])
 
     and the values of the singular functions at the Gauss sampling points can
-    be reconstructed from the singular vectors ``u`` and ``v`` as follows:
+    be reconstructed from the singular vectors ``u`` and ``v`` as follows::
 
         u[l,i] ≈ sqrt(wx[i]) u[l](x[i])
         v[l,j] ≈ sqrt(wy[j]) u[l](y[j])
@@ -221,14 +221,14 @@ class CentrosymmSVE(AbstractSVE):
 
     For a centrosymmetric kernel ``K``, i.e., a kernel satisfying:
     ``K(x, y) == K(-x, -y)``, one can make the following ansatz for the
-    singular functions:
+    singular functions::
 
         u[l](x) = ured[l](x) + sign[l] * ured[l](-x)
         v[l](y) = vred[l](y) + sign[l] * ured[l](-y)
 
     where ``sign[l]`` is either +1 or -1.  This means that the singular value
     expansion can be block-diagonalized into an even and an odd part by
-    (anti-)symmetrizing the kernel:
+    (anti-)symmetrizing the kernel::
 
         Keven = K(x, y) + K(x, -y)
         Kodd  = K(x, y) - K(x, -y)

--- a/src/sparse_ir/sve.py
+++ b/src/sparse_ir/sve.py
@@ -96,6 +96,22 @@ class AbstractSVE:
         raise NotImplementedError()
 
 
+class SVEResult:
+    """Result of singular value expansion"""
+    def __init__(self, u, s, v, K, eps=None):
+        self.u = u
+        self.s = s
+        self.v = v
+
+        # In addition to its SVE, we remember the type of kernel and also the
+        # accuracy to which the SVE was computed.
+        self.K = K
+        self.eps = eps
+
+    def __iter__(self):
+        return iter((self.u, self.s, self.v))
+
+
 class SamplingSVE(AbstractSVE):
     """SVE to SVD translation by sampling technique [1].
 
@@ -170,7 +186,7 @@ class SamplingSVE(AbstractSVE):
         vly = poly.PiecewiseLegendrePoly(
                         v_data.astype(dtype), self._segs_y.astype(dtype))
         _canonicalize(ulx, vly)
-        return ulx, s, vly
+        return SVEResult(ulx, s, vly, self.K, self.eps)
 
 
 class CentrosymmSVE(AbstractSVE):
@@ -249,7 +265,7 @@ class CentrosymmSVE(AbstractSVE):
         full_hints = self.K.sve_hints(self.eps)
         u = poly.PiecewiseLegendrePoly(u_data, full_hints.segments_x, symm=signs)
         v = poly.PiecewiseLegendrePoly(v_data, full_hints.segments_y, symm=signs)
-        return u, s, v
+        return SVEResult(u, s, v, self.K, self.eps)
 
 
 def _choose_accuracy(eps, work_dtype):

--- a/test/test_poly.py
+++ b/test/test_poly.py
@@ -11,7 +11,7 @@ import pytest
 
 
 def test_shape(sve_logistic):
-    u, s, v = sve_logistic[42]
+    u, s, v = sve_logistic[42].part()
     l = s.size
     assert u.shape == (l,)
 
@@ -30,7 +30,7 @@ def test_slice(sve_logistic):
 
 
 def test_eval(sve_logistic):
-    u, s, v = sve_logistic[42]
+    u, s, v = sve_logistic[42].part()
     l = s.size
 
     # evaluate
@@ -42,7 +42,7 @@ def test_eval(sve_logistic):
 
 
 def test_broadcast(sve_logistic):
-    u, s, v = sve_logistic[42]
+    u, s, v = sve_logistic[42].part()
 
     x = [0.3, 0.5]
     l = [2, 7]
@@ -51,7 +51,7 @@ def test_broadcast(sve_logistic):
 
 
 def test_matrix_hat(sve_logistic):
-    u, s, v = sve_logistic[42]
+    u, s, v = sve_logistic[42].part()
     uhat = poly.PiecewiseLegendreFT(u, "odd")
 
     n = np.array([1, 3, 5, -1, -3, 5])
@@ -63,7 +63,7 @@ def test_matrix_hat(sve_logistic):
 
 @pytest.mark.parametrize("lambda_, atol", [(42, 1e-13), (1E+4, 1e-13)])
 def test_overlap(sve_logistic, lambda_, atol):
-    u, s, v = sve_logistic[lambda_]
+    u, s, v = sve_logistic[lambda_].part()
 
     # Keep only even number of polynomials
     u, s, v = u[:2*(s.size//2)], s[:2*(s.size//2)], v[:2*(s.size//2)]
@@ -76,7 +76,7 @@ def test_overlap(sve_logistic, lambda_, atol):
 
 @pytest.mark.parametrize("lambda_, atol", [(42, 1e-13), (1E+4, 1e-13)])
 def test_overlap_break_points(sve_logistic, lambda_, atol):
-    u, s, v = sve_logistic[lambda_]
+    u, s, v = sve_logistic[lambda_].part()
 
     D = 0.5 * v.xmax
     rhow = lambda omega: np.where(abs(omega)<=D, 1, 0)
@@ -87,7 +87,7 @@ def test_overlap_break_points(sve_logistic, lambda_, atol):
 
 
 def test_eval_unique(sve_logistic):
-    u, s, v = sve_logistic[42]
+    u, s, v = sve_logistic[42].part()
     uhat = poly.PiecewiseLegendreFT(u, "odd")
 
     # evaluate

--- a/test/test_poly.py
+++ b/test/test_poly.py
@@ -22,9 +22,6 @@ def test_shape(sve_logistic):
 def test_slice(sve_logistic):
     sve_result = sve_logistic[42]
 
-    basis = sparse_ir.DimensionlessBasis('F', 42, sve_result=sve_result)
-    assert basis[:5].size == 5
-
     basis = sparse_ir.FiniteTempBasis('F', 4.2, 10, sve_result=sve_result)
     assert basis[:4].size == 4
 

--- a/test/test_sampling.py
+++ b/test/test_sampling.py
@@ -65,8 +65,8 @@ def test_axis0():
 
 @pytest.mark.parametrize("stat, lambda_", [('B', 42), ('F', 42)])
 def test_tau_noise(sve_logistic, stat, lambda_):
-    basis = sparse_ir.DimensionlessBasis(stat, lambda_,
-                                         sve_result=sve_logistic[lambda_])
+    basis = sparse_ir.FiniteTempBasis(stat, 1, lambda_,
+                                      sve_result=sve_logistic[lambda_])
     smpl = sparse_ir.TauSampling(basis)
     rng = np.random.RandomState(4711)
 
@@ -84,8 +84,8 @@ def test_tau_noise(sve_logistic, stat, lambda_):
 
 @pytest.mark.parametrize("stat, lambda_", [('B', 42), ('F', 42)])
 def test_wn_noise(sve_logistic, stat, lambda_):
-    basis = sparse_ir.DimensionlessBasis(stat, lambda_,
-                                         sve_result=sve_logistic[lambda_])
+    basis = sparse_ir.FiniteTempBasis(stat, 1, lambda_,
+                                      sve_result=sve_logistic[lambda_])
     smpl = sparse_ir.MatsubaraSampling(basis)
     rng = np.random.RandomState(4711)
 

--- a/test/test_scipost_sample_code.py
+++ b/test/test_scipost_sample_code.py
@@ -4,34 +4,6 @@
 
 # Sample codes in the SciPost review paper
 
-def test_sample1():
-    # Compute IR basis for fermions and \Lambda = \beta * \omega_max = 1000
-    import sparse_ir
-    import numpy as np
-
-    lambda_  = 1000
-    eps = 1e-8 # cut-off value for singular values
-    b_xy = sparse_ir.DimensionlessBasis('F', lambda_, eps)
-
-    # All singular values
-    print("singular values: ", b_xy.s)
-    print("u_0(0.1)", b_xy.u[0](0.1))
-    print("v_0(0.1)", b_xy.v[0](0.1))
-
-    print("n-th derivative of u_l(x) and v_l(y)")
-    for n in range(1,3):
-        u_n = b_xy.u.deriv(n)
-        v_n = b_xy.v.deriv(n)
-        print(" n= ", n, u_n[0](0.1))
-        print(" n= ", n, v_n[0](0.1))
-
-    # Compute u_{ln} as a matrix for the first
-    # 10 non-nagative fermionic Matsubara frequencies
-    # Fermionic/bosonic frequencies are denoted by odd/even integers.
-    hatF_t = b_xy.uhat(2*np.arange(10)+1)
-    print(hatF_t.shape)
-
-
 def test_sample2():
     # Compute IR basis for fermions and \beta = 100 and \omega_max = 10
     import sparse_ir

--- a/test/test_sve.py
+++ b/test/test_sve.py
@@ -25,16 +25,16 @@ def _check_smooth(u, s, uscale, fudge_factor):
 
 @pytest.mark.parametrize("lambda_", [10, 42, 10_000])
 def test_smooth(sve_logistic, lambda_):
-    basis = sparse_ir.DimensionlessBasis('F', lambda_,
-                                         sve_result=sve_logistic[lambda_])
+    basis = sparse_ir.FiniteTempBasis('F', 1, lambda_,
+                                      sve_result=sve_logistic[lambda_])
     _check_smooth(basis.u, basis.s, 2*basis.u(1).max(), 24)
     _check_smooth(basis.v, basis.s, 50, 20)
 
 
 @pytest.mark.parametrize("lambda_", [10, 42, 10_000])
 def test_num_roots_u(sve_logistic, lambda_):
-    basis = sparse_ir.DimensionlessBasis('F', lambda_,
-                                         sve_result=sve_logistic[lambda_])
+    basis = sparse_ir.FiniteTempBasis('F', 1, lambda_,
+                                      sve_result=sve_logistic[lambda_])
     for i in range(basis.u.size):
         ui_roots = basis.u[i].roots()
         assert ui_roots.size == i
@@ -43,8 +43,8 @@ def test_num_roots_u(sve_logistic, lambda_):
 @pytest.mark.parametrize("stat", ['F', 'B'])
 @pytest.mark.parametrize("lambda_", [10, 42, 10_000])
 def test_num_roots_uhat(sve_logistic, stat, lambda_):
-    basis = sparse_ir.DimensionlessBasis(stat, lambda_,
-                                         sve_result=sve_logistic[lambda_])
+    basis = sparse_ir.FiniteTempBasis(stat, 1, lambda_,
+                                      sve_result=sve_logistic[lambda_])
     for i in [0, 1, 7, 10]:
         x0 = basis.uhat[i].extrema()
         assert i + 1 <= x0.size <= i + 2


### PR DESCRIPTION
This does quite a bit of refactoring:

 - it removes the `DimensionlessBasis` instance
 - it decouples the SVE accuracy from its truncation, allowing us access to higher-order basis functions

Please @Samuel3008 also look at this, since I would like to have a similar change for the julia lib