### PR TITLE
Bump to v2.0.0a10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sparse-ir"
-version = "2.0.0a9"
+version = "2.0.0a10"
 description = "Python bindings for the libsparseir library, providing efficient sparse intermediate representation for many-body physics calculations"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump version to 2.0.0a10.

This PR also includes recent documentation improvements:
- Added release process documentation to README
- Added pylibsparseir dependency update procedure to README

## Changes

- `pyproject.toml`: version `2.0.0a9` → `2.0.0a10`
- `.conda/meta.yaml`: automatically reads version from pyproject.toml

## After Merge

After merging this PR to mainline:

1. Create and push tag:
   ```bash
   git checkout mainline
   git pull origin mainline
   git tag v2.0.0a10
   git push origin v2.0.0a10
   ```

2. Automated builds will trigger:
   - PyPI: `wheel.yml` workflow
   - conda: `conda.yml` workflow (SpM-lab channel)