### PR TITLE
Bump version to v2.0.0 (not alpha!!!)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sparse-ir"
-version = "2.0.0a10"
+version = "2.0.0"
 description = "Python bindings for the libsparseir library, providing efficient sparse intermediate representation for many-body physics calculations"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Preparing the official release of SparseIR.jl v2.0.0.