### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sparse-ir"
-version = "2.0.0"
+version = "2.1.0"
 description = "Python bindings for the libsparseir library, providing efficient sparse intermediate representation for many-body physics calculations"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump version from 2.0.0 to 2.1.0

## Changes in 2.1.0

### New Features
- Added `deriv(n)` method to `FunctionSet` class for computing n-th derivatives
- Added `deriv(n)` method to `PiecewiseLegendrePolyVector` class

### Dependencies
- Updated to pylibsparseir v0.8.0 (from v0.7.x)

### Bug Fixes
- Fixed test compatibility with pylibsparseir v0.8.0

## Version Rationale

Using **2.1.0 (minor)** instead of 2.0.1 (patch) because:
- New API methods added (`deriv()`)
- Maintains backward compatibility
- No breaking changes

## Related PRs
- #69: Update to pylibsparseir v0.8.0 and add derivative support