### PR TITLE
Bump version to 2.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sparse-ir"
-version = "2.1.0"
+version = "2.1.1"
 description = "Python bindings for the libsparseir library, providing efficient sparse intermediate representation for many-body physics calculations"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump version from 2.1.0 to 2.1.1

## Changes in 2.1.1

### Backward Compatibility (from PR #71)
- **`work_dtype` parameter support in `sve.compute()`**: Accepts (but ignores) this parameter for backward compatibility with sparse-ir 1.x
- **`kernel` parameter support in `FiniteTempBasis.__init__()`**: Accepts kernel parameter (deprecated) for legacy code compatibility
- **`max_size` parameter**: Made optional with keyword-only argument

### Bug Fixes
- Fixed `MatsubaraSampling.fit()` bug

## Version Rationale

Using **2.1.1 (patch)** because:
- Adds backward compatibility without changing existing behavior
- Fixes a bug in MatsubaraSampling.fit()
- No new features, only compatibility improvements

## Compatibility

This release allows legacy code (like dcorelib) using sparse-ir 1.x API to work with sparse-ir 2.x without modification:

```python
# Legacy code still works!
sve_result = sparse_ir.sve.compute(kernel, eps=1e-5, work_dtype=numpy.float64)
basis = sparse_ir.FiniteTempBasis('F', beta, wmax, kernel=kernel)
```

## Testing
- All 95 tests pass
- No breaking changes

## Related PRs
- #71: Add backward compatibility for sparse-ir 1.x API