### PR TITLE
chore: require pylibsparseir 0.8.3

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -21,12 +21,12 @@ requirements:
     - scipy
     - setuptools
     - wheel
-    - spm-lab::pylibsparseir >=0.8.0,<0.9.0
+    - spm-lab::pylibsparseir >=0.8.3,<0.9.0
   run:
     - numpy
     - python
     - scipy
-    - spm-lab::pylibsparseir >=0.8.0,<0.9.0
+    - spm-lab::pylibsparseir >=0.8.3,<0.9.0
 
 #test:
 #  imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "sparse-ir"
-version = "2.1.1"
+version = "2.1.2"
 description = "Python bindings for the libsparseir library, providing efficient sparse intermediate representation for many-body physics calculations"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "scipy",
-    "pylibsparseir>=0.8.0,<0.9.0",
+    "pylibsparseir>=0.8.3,<0.9.0",
 ]
 authors = [
     {name = "SpM-lab"}


### PR DESCRIPTION
## Summary
- require `pylibsparseir>=0.8.3,<0.9.0` in `pyproject.toml`
- keep the conda recipe in sync with the same dependency floor

## Verification
- python3 check_libsparseir_version_consistency.py
- python3 -m venv /tmp/sparse-ir-published-083
- python -m pip install -U pip setuptools wheel pytest numpy scipy
- python -m pip install -e /Users/hiroshi/projects/sparse-ir/sparse-ir
- pytest tests/ -q
- result: `95 passed, 8 skipped` against published `pylibsparseir 0.8.3`