### PR TITLE
Restore accuracy truncation bound in 2.1.2

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -21,12 +21,12 @@ requirements:
     - scipy
     - setuptools
     - wheel
-    - spm-lab::pylibsparseir >=0.8.0,<0.9.0
+    - spm-lab::pylibsparseir >=0.8.0,<0.10.0
   run:
     - numpy
     - python
     - scipy
-    - spm-lab::pylibsparseir >=0.8.0,<0.9.0
+    - spm-lab::pylibsparseir >=0.8.0,<0.10.0
 
 #test:
 #  imports:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.md
+include README.rst
 recursive-include src/sparse_ir *.py
 global-exclude *.pyc
 global-exclude __pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "sparse-ir"
-version = "2.1.1"
+version = "2.1.2"
 description = "Python bindings for the libsparseir library, providing efficient sparse intermediate representation for many-body physics calculations"
-readme = "README.md"
+readme = "README.rst"
 requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "scipy",
-    "pylibsparseir>=0.8.0,<0.9.0",
+    "pylibsparseir>=0.8.0,<0.10.0",
 ]
 authors = [
     {name = "SpM-lab"}
@@ -19,6 +19,8 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Physics",
 ]
 

--- a/src/sparse_ir/basis.py
+++ b/src/sparse_ir/basis.py
@@ -228,8 +228,11 @@ class FiniteTempBasis(AbstractBasis):
 
     @property
     def accuracy(self):
-        """Overall accuracy bound."""
-        return self.s[-1] / self.s[0]
+        """Overall truncation error bound."""
+        sve_s = self.sve_result.s
+        if sve_s.size > self.size:
+            return sve_s[self.size] / sve_s[0]
+        return sve_s[-1] / sve_s[0]
 
     @property
     def shape(self):

--- a/tests/test_sve.py
+++ b/tests/test_sve.py
@@ -19,14 +19,36 @@ class TestSVEAccuracy:
         """Test that basis accuracy meets expected bounds."""
         eps = 1e-6
         basis = sparse_ir.FiniteTempBasis(stat, beta, wmax, eps)
+        sve_s = basis.sve_result.s
 
-        # Basic properties
-        assert 0 < basis.accuracy <= basis.significance[-1]
+        # Accuracy is the relative significance of the first singular value
+        # excluded from the basis.
+        assert sve_s.size > basis.size
+        expected_accuracy = sve_s[basis.size] / sve_s[0]
+        assert basis.accuracy == expected_accuracy
         assert basis.significance[0] == 1.0
-        assert basis.accuracy <= basis.s[-1] / basis.s[0]
+        assert basis.accuracy < eps <= basis.significance[-1]
 
-        # Accuracy should be better than requested epsilon (with some tolerance)
-        assert basis.accuracy <= 10 * eps, f"Accuracy {basis.accuracy} should be close to eps {eps}"
+    def test_accuracy_with_max_size(self):
+        """Test accuracy when max_size, rather than epsilon, truncates."""
+        eps = 1e-6
+        basis = sparse_ir.FiniteTempBasis(
+            'F', 1.0, 42.0, eps, max_size=5
+        )
+        sve_s = basis.sve_result.s
+
+        assert basis.size == 5
+        assert basis.accuracy == sve_s[basis.size] / sve_s[0]
+        assert basis.accuracy > eps
+        assert basis.accuracy < basis.significance[-1]
+
+    def test_accuracy_without_excluded_singular_value(self):
+        """Test the fallback when the SVE contains no excluded value."""
+        basis = sparse_ir.FiniteTempBasis('F', 1e-3, 1e-3, 1e-100)
+        sve_s = basis.sve_result.s
+
+        assert sve_s.size == basis.size
+        assert basis.accuracy == sve_s[-1] / sve_s[0]
 
     @pytest.mark.parametrize("stat,beta,wmax", BASIS_PARAMS)
     def test_singular_value_properties(self, stat, beta, wmax):
@@ -132,5 +154,4 @@ class TestBasisConsistency:
         # We just check they're both reasonable
         assert 5 <= f_basis.size <= 100
         assert 5 <= b_basis.size <= 100
-
 


### PR DESCRIPTION
## Summary

- restore the sparse-ir 1.x meaning of `FiniteTempBasis.accuracy`: the relative first excluded singular value
- retain the last-included fallback only when the full SVE has no excluded value
- cover epsilon truncation, `max_size` truncation, and the no-excluded-value case
- allow the upcoming pylibsparseir 0.9.x release and advertise Python 3.14 support
- fix the README filename used by package metadata and the source manifest
- bump sparse-ir to 2.1.2

## Why

In 2.x, `accuracy` returned the last included singular value. That reversed the relationship expected by callers using `requested_tolerance > basis.accuracy`. The first excluded singular value is the truncation error bound and matches sparse-ir 1.x behavior.

## Verification

- Python 3.11: 97 passed, 8 skipped
- Python 3.14 with locally built pylibsparseir 0.9.0 wheel: 97 passed, 8 skipped
- source distribution and universal wheel build successfully
- pylibsparseir dependency specifications are consistent between PyPI and conda metadata

## Release ordering

This PR accepts pylibsparseir 0.9.x, but Python 3.14 installation requires the CPython 3.14 wheel prepared in SpM-lab/sparse-ir-rs#251. Publish pylibsparseir 0.9.0 first, then sparse-ir 2.1.2.
