### PR TITLE
Require pylibsparseir 0.8.3 or newer

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -21,12 +21,12 @@ requirements:
     - scipy
     - setuptools
     - wheel
-    - spm-lab::pylibsparseir >=0.8.0,<0.10.0
+    - spm-lab::pylibsparseir >=0.8.3,<0.10.0
   run:
     - numpy
     - python
     - scipy
-    - spm-lab::pylibsparseir >=0.8.0,<0.10.0
+    - spm-lab::pylibsparseir >=0.8.3,<0.10.0
 
 #test:
 #  imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "scipy",
-    "pylibsparseir>=0.8.0,<0.10.0",
+    "pylibsparseir>=0.8.3,<0.10.0",
 ]
 authors = [
     {name = "SpM-lab"}


### PR DESCRIPTION
## Summary

- preserve the `pylibsparseir>=0.8.3` minimum from #76
- retain the `<0.10.0` upper bound added for pylibsparseir 0.9 compatibility in #77
- keep PyPI and conda dependency specifications aligned

## Why

PR #76 predates #77 and now conflicts with `mainline`. Its minimum-version requirement is still relevant, but it should be applied on top of the 2.1.2 release changes instead of merging the stale branch directly.

## Validation

- `python3 check_libsparseir_version_consistency.py`
- `.venv/bin/python -m pytest tests/ -q`
- result: `97 passed, 8 skipped`